### PR TITLE
Fix GCC Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,72 @@
+name: Main
+
+on:
+  push:
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ['Release']
+        config:
+          - { name: '🐧 Linux GCC', os: ubuntu-latest }
+          - { name: '🪟 Windows MSVC', os: windows-latest }
+
+    name: 🛠 Build / ${{ matrix.config.name }} (${{ matrix.build_type }})
+    runs-on: ${{ matrix.config.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Dependencies (Linux)
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache ninja-build
+
+      - name: Install Dependencies (Windows)
+        if: matrix.config.os == 'windows-latest'
+        run: |
+          choco upgrade ccache ninja
+
+      - name: Setup MSVC (Windows)
+        if: matrix.config.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          max-size: '10G'
+          key: ${{ matrix.config.os }}-${{ matrix.build_type }}
+
+      - name: Configure
+        run: >
+          mkdir build
+
+          cmake
+          -B build
+          -G "Ninja"
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          --install-prefix ${{ github.workspace }}/install-${{ matrix.build_type }}
+          .
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Install
+        run: cmake --install build
+
+      - name: Upload artifact
+        if: matrix.build_type == 'Release'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.event.repository.name }}-Release
+          path: |
+            ${{ github.workspace }}/install-${{ matrix.build_type }}/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *-build/
 src/test.cpp
 test.exe
+.cache/

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -26,28 +26,28 @@ public:
     void setNearstar(double parsis_x, double parsis_y, double parsis_z);
     void saveModels() const;
 
-    void Feltyrion::setAPTargetted(int i);
-    void Feltyrion::setAPTargetX(double x);
-    double Feltyrion::getAPTargetX();
-    void Feltyrion::setAPTargetY(double y);
-    double Feltyrion::getAPTargetY();
-    void Feltyrion::setAPTargetZ(double z);
-    double Feltyrion::getAPTargetZ();
+    void setAPTargetted(int i);
+    void setAPTargetX(double x);
+    double getAPTargetX();
+    void setAPTargetY(double y);
+    double getAPTargetY();
+    void setAPTargetZ(double z);
+    double getAPTargetZ();
 
-    void Feltyrion::setDzatX(double x);
-    double Feltyrion::getDzatX();
-    void Feltyrion::setDzatY(double y);
-    double Feltyrion::getDzatY();
-    void Feltyrion::setDzatZ(double z);
-    double Feltyrion::getDzatZ();
+    void setDzatX(double x);
+    double getDzatX();
+    void setDzatY(double y);
+    double getDzatY();
+    void setDzatZ(double z);
+    double getDzatZ();
 
-    double Feltyrion::getIPTargettedX();
-    double Feltyrion::getIPTargettedY();
-    double Feltyrion::getIPTargettedZ();
+    double getIPTargettedX();
+    double getIPTargettedY();
+    double getIPTargettedZ();
 
-    double Feltyrion::getNearstarX();
-    double Feltyrion::getNearstarY();
-    double Feltyrion::getNearstarZ();
+    double getNearstarX();
+    double getNearstarY();
+    double getNearstarZ();
 
     void setIPTargetted(int new_target);
     int8_t getIPTargetted();


### PR DESCRIPTION
This MR does two things:

- Fixes the build on Linux systems. GCC does not like the additional prefix before functions in a class, whereas MSVC evidently allows it.
- Adds a build action, ripped from https://github.com/asmaloney/GDExtensionTemplate/blob/master/.github/workflows/main.yml