### PR TITLE
Implement surface scattering and surface mesh forwarding

### DIFF
--- a/src/Feltyrion.cpp
+++ b/src/Feltyrion.cpp
@@ -34,6 +34,7 @@ extern void process_comm_bin_file();
 extern void iperficie(int16_t additional_quadrants);
 extern void prep_iperficie();
 extern void getAllFragments();
+extern int8_t capture_poly3d;
 
 godot::Ref<godot::Image> Feltyrion::getPaletteAsImage() const
 {
@@ -314,23 +315,36 @@ void cb_RingParticleFound(double xlight, double ylight, double zlight, double ra
     );
 }
 
-void cb_SurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore)
+void cb_SurfacePolygon3Found(int8_t what, double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore)
 {
-    instance->onSurfacePolygon3Found(
-        x0,
-        x1,
-        x2,
-        y0,
-        y1,
-        y2,
-        z0,
-        z1,
-        z2,
-        colore
-    );
+    if (what == POLY3D_CAPTURE_SCATTERING) {
+        instance->onScatteringPolygon3Found(
+            x0,
+            x1,
+            x2,
+            y0,
+            y1,
+            y2,
+            z0,
+            z1,
+            z2,
+            colore
+        );
+    } else if (what == POLY3D_CAPTURE_SURFACE) {
+        instance->onSurfacePolygon3Found(
+            x0,
+            x1,
+            x2,
+            y0,
+            y1,
+            y2,
+            z0,
+            z1,
+            z2,
+            colore
+        );
+    }
 }
-
-bool capture_poly3d = false;
 
 void cb_Star(double x, double y, double z, double id_code)
 {
@@ -427,6 +441,16 @@ void Feltyrion::onRingParticleFound(double xlight, double ylight, double zlight,
 void Feltyrion::onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore) {
    godot::Object::emit_signal(
         "found_surface_polygon3",
+        x0, x1, x2,
+        y0, y1, y2,
+        z0, z1, z2,
+        colore
+   );
+}
+
+void Feltyrion::onScatteringPolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore) {
+   godot::Object::emit_signal(
+        "found_scattering_polygon3",
         x0, x1, x2,
         y0, y1, y2,
         z0, z1, z2,
@@ -631,7 +655,9 @@ void Feltyrion::unfreeze() {
 
 void Feltyrion::generateSurfacePolygons() {
     prep_iperficie();
+    capture_poly3d = POLY3D_CAPTURE_SURFACE;
     getAllFragments();
+    capture_poly3d = POLY3D_CAPTURE_NONE;
 }
 
 void Feltyrion::processCommBinFile() {
@@ -848,6 +874,19 @@ void Feltyrion::_bind_methods()
         godot::PropertyInfo( godot::Variant::INT, "unconditioned_color" ) ) );
 
     ADD_SIGNAL( godot::MethodInfo( "found_surface_polygon3", 
+        godot::PropertyInfo( godot::Variant::FLOAT, "x0" ), 
+        godot::PropertyInfo( godot::Variant::FLOAT, "x1" ), 
+        godot::PropertyInfo(godot::Variant::FLOAT, "x2"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y0"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y1"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y2"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z0"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z1"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z2"),
+        godot::PropertyInfo(godot::Variant::INT, "color")
+    ));
+
+    ADD_SIGNAL( godot::MethodInfo( "found_scattering_polygon3", 
         godot::PropertyInfo( godot::Variant::FLOAT, "x0" ), 
         godot::PropertyInfo( godot::Variant::FLOAT, "x1" ), 
         godot::PropertyInfo(godot::Variant::FLOAT, "x2"),

--- a/src/Feltyrion.cpp
+++ b/src/Feltyrion.cpp
@@ -33,6 +33,7 @@ extern void unfreeze();
 extern void process_comm_bin_file();
 extern void iperficie(int16_t additional_quadrants);
 extern void prep_iperficie();
+extern void getAllFragments();
 
 godot::Ref<godot::Image> Feltyrion::getPaletteAsImage() const
 {
@@ -329,7 +330,7 @@ void cb_SurfacePolygon3Found(double x0, double x1, double x2, double y0, double 
     );
 }
 
-bool capture_poly3d;
+bool capture_poly3d = false;
 
 void cb_Star(double x, double y, double z, double id_code)
 {
@@ -628,6 +629,11 @@ void Feltyrion::unfreeze() {
     ::unfreeze();
 }
 
+void Feltyrion::generateSurfacePolygons() {
+    prep_iperficie();
+    getAllFragments();
+}
+
 void Feltyrion::processCommBinFile() {
     process_comm_bin_file();
 }
@@ -769,6 +775,8 @@ void Feltyrion::_bind_methods()
     godot::ClassDB::bind_method( godot::D_METHOD( "freeze" ), &Feltyrion::freeze );
     godot::ClassDB::bind_method( godot::D_METHOD( "unfreeze" ), &Feltyrion::unfreeze );
     godot::ClassDB::bind_method( godot::D_METHOD( "processCommBinFile" ), &Feltyrion::processCommBinFile );
+
+    godot::ClassDB::bind_method( godot::D_METHOD( "generateSurfacePolygons" ), &Feltyrion::generateSurfacePolygons );
 
     godot::ClassDB::bind_method( godot::D_METHOD( "get_cwd" ), &Feltyrion::getCWD );
 

--- a/src/Feltyrion.cpp
+++ b/src/Feltyrion.cpp
@@ -31,6 +31,8 @@ extern void not_actually_draw_planet(int16_t target_body);
 extern void freeze();
 extern void unfreeze();
 extern void process_comm_bin_file();
+extern void iperficie(int16_t additional_quadrants);
+extern void prep_iperficie();
 
 godot::Ref<godot::Image> Feltyrion::getPaletteAsImage() const
 {
@@ -311,6 +313,24 @@ void cb_RingParticleFound(double xlight, double ylight, double zlight, double ra
     );
 }
 
+void cb_SurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore)
+{
+    instance->onSurfacePolygon3Found(
+        x0,
+        x1,
+        x2,
+        y0,
+        y1,
+        y2,
+        z0,
+        z1,
+        z2,
+        colore
+    );
+}
+
+bool capture_poly3d;
+
 void cb_Star(double x, double y, double z, double id_code)
 {
     instance->onStarFound(
@@ -401,6 +421,16 @@ void Feltyrion::onRingParticleFound(double xlight, double ylight, double zlight,
         "found_ring_particle",
         xlight, ylight, zlight, radii, unconditioned_color
     );
+}
+
+void Feltyrion::onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore) {
+   godot::Object::emit_signal(
+        "found_surface_polygon3",
+        x0, x1, x2,
+        y0, y1, y2,
+        z0, z1, z2,
+        colore
+   );
 }
 
 void Feltyrion::onStarFound(double x, double y, double z, double id_code) {
@@ -586,6 +616,7 @@ void Feltyrion::loopOneIter()
 }
 
 void Feltyrion::preparePlanetSurface() {
+    prep_iperficie();
     planetary_main();
 }
 
@@ -797,5 +828,18 @@ void Feltyrion::_bind_methods()
         godot::PropertyInfo( godot::Variant::FLOAT, "zlight" ), 
         godot::PropertyInfo( godot::Variant::FLOAT, "radii" ), 
         godot::PropertyInfo( godot::Variant::INT, "unconditioned_color" ) ) );
+
+    ADD_SIGNAL( godot::MethodInfo( "found_surface_polygon3", 
+        godot::PropertyInfo( godot::Variant::FLOAT, "x0" ), 
+        godot::PropertyInfo( godot::Variant::FLOAT, "x1" ), 
+        godot::PropertyInfo(godot::Variant::FLOAT, "x2"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y0"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y1"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "y2"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z0"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z1"),
+        godot::PropertyInfo(godot::Variant::FLOAT, "z2"),
+        godot::PropertyInfo(godot::Variant::INT, "color")
+    ));
 
 }

--- a/src/Feltyrion.cpp
+++ b/src/Feltyrion.cpp
@@ -673,18 +673,28 @@ godot::Ref<godot::Image> Feltyrion::returnRuinschartImage() {
     return ref;
 }
 
-godot::Ref<godot::Image> Feltyrion::returnTxtrImage() {
+/**
+ * @brief Get an image (RGBA8/FORMAT_L8) for the planet surface texture.
+ * 
+ * @param raw__one_byte get the image as a one-byte-per-pixel image (FORMAT_L8), without colormap applied
+ * @return godot::Ref<godot::Image> 
+ */
+godot::Ref<godot::Image> Feltyrion::returnTxtrImage(bool raw__one_byte) {
     auto pba = godot::PackedByteArray();
     int a = 0;
     for (uint16_t y = 0; y < 256; y++) {
         for (uint16_t x = 0; x < 256; x++) {
             uint8_t val = p_background[(y*256)+x];
-            pba.append(surface_palette[(val) * 3] * 4);
-            pba.append(surface_palette[(val) * 3 + 1] * 4);
-            pba.append(surface_palette[(val) * 3 + 2] * 4);
+            if (raw__one_byte) {
+                pba.append(val);
+            } else {
+                pba.append(surface_palette[(val) * 3] * 4);
+                pba.append(surface_palette[(val) * 3 + 1] * 4);
+                pba.append(surface_palette[(val) * 3 + 2] * 4);
+            }
         }
     }
-    auto image = godot::Image::create_from_data(256, 256, false, godot::Image::FORMAT_RGB8, pba);
+    auto image = godot::Image::create_from_data(256, 256, false, raw__one_byte ? godot::Image::FORMAT_L8 : godot::Image::FORMAT_RGB8, pba);
     godot::Ref<godot::Image> ref = image;
     return ref;
 }

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -116,6 +116,7 @@ public:
     void scanStars();
     void onRingParticleFound(double xlight, double ylight, double zlight, double radii, int unconditioned_color);
     void onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
+    void onScatteringPolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
     void onStarFound(double x, double y, double z, double id_code);
     void onPlanetFound(int8_t index, double planet_id, double seedval, double x, double y, double z, int8_t type, int16_t owner, int8_t moonid, double ring, double tilt, double ray, double orb_ray, double orb_tilt, double orb_orient, double orb_ecc, int16_t rtperiod, int16_t rotation, int16_t viewpoint, int16_t term_start, int16_t term_end, int16_t qsortindex, float qsortdist);
     void updateTime();

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -62,6 +62,8 @@ public:
     void freeze();
     void unfreeze();
     void processCommBinFile();
+    
+    void generateSurfacePolygons();
 
     godot::String getCWD() const;
 

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -57,7 +57,7 @@ public:
     godot::Ref<godot::Image> returnSkyImage();
     godot::Ref<godot::Image> returnSurfacemapImage();
     godot::Ref<godot::Image> returnRuinschartImage();
-    godot::Ref<godot::Image> returnTxtrImage();
+    godot::Ref<godot::Image> returnTxtrImage(bool raw__one_byte);
 
     void freeze();
     void unfreeze();

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -113,6 +113,7 @@ public:
     void unlock();
     void scanStars();
     void onRingParticleFound(double xlight, double ylight, double zlight, double radii, int unconditioned_color);
+    void onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
     void onStarFound(double x, double y, double z, double id_code);
     void onPlanetFound(int8_t index, double planet_id, double seedval, double x, double y, double z, int8_t type, int16_t owner, int8_t moonid, double ring, double tilt, double ray, double orb_ray, double orb_tilt, double orb_orient, double orb_ecc, int16_t rtperiod, int16_t rotation, int16_t viewpoint, int16_t term_start, int16_t term_end, int16_t qsortindex, float qsortdist);
     void updateTime();

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -2,6 +2,12 @@
 
 #include "godot_cpp/classes/control.hpp"
 #include "godot_cpp/classes/node3d.hpp"
+#include "godot_cpp/classes/surface_tool.hpp"
+#include "godot_cpp/classes/packed_scene.hpp"
+#include "godot_cpp/classes/resource_loader.hpp"
+#include "godot_cpp/classes/image_texture.hpp"
+#include "godot_cpp/classes/material.hpp"
+#include "godot_cpp/classes/shader_material.hpp"
 #include "godot_cpp/core/binder_common.hpp"
 #include "godot_cpp/classes/mutex.hpp"
 
@@ -115,6 +121,9 @@ public:
     void unlock();
     void scanStars();
     void onRingParticleFound(double xlight, double ylight, double zlight, double radii, int unconditioned_color);
+    void Feltyrion::prepareSurfaceScattering(godot::Node3D* target, godot::String scenePath);
+    void onScatteringBegin();
+    void onScatteringEnd();
     void onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
     void onScatteringPolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
     void onStarFound(double x, double y, double z, double id_code);
@@ -132,4 +141,9 @@ protected:
     static void _bind_methods();
 private:
     godot::Mutex mutex;
+    godot::Node3D *surfaceScatteringNode;
+    godot::Ref<godot::SurfaceTool> surfaceTool;
+    godot::Ref<godot::PackedScene> scatteringObjectScene;
+    godot::Ref<godot::ImageTexture> surfacePaletteTxtr;
+    godot::Ref<godot::ImageTexture> surfaceAlbedoL8Txtr;
 };

--- a/src/Feltyrion.h
+++ b/src/Feltyrion.h
@@ -121,7 +121,7 @@ public:
     void unlock();
     void scanStars();
     void onRingParticleFound(double xlight, double ylight, double zlight, double radii, int unconditioned_color);
-    void Feltyrion::prepareSurfaceScattering(godot::Node3D* target, godot::String scenePath);
+    void prepareSurfaceScattering(godot::Node3D* target, godot::String scenePath);
     void onScatteringBegin();
     void onScatteringEnd();
     void onSurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);

--- a/src/noctis-1.cpp
+++ b/src/noctis-1.cpp
@@ -521,7 +521,9 @@ rockrep:
     ty[0]  = hpoint(tx[0], tz[0]);
     ty[1]  = hpoint(tx[1], tz[1]);
 
+    #ifndef WITH_GODOT
     if (!facing(tx, ty, tz)) {
+    #endif
         if (depth < 2) {
             tx[3] = tx[2];
             ty[3] = ty[2];
@@ -530,7 +532,9 @@ rockrep:
         } else {
             poly3d(tx, ty, tz, 3, rc[0]);
         }
+    #ifndef WITH_GODOT
     }
+    #endif
 
     tx[0] = px[1];
     tx[1] = px[2];
@@ -539,7 +543,9 @@ rockrep:
     ty[0] = hpoint(tx[0], tz[0]);
     ty[1] = hpoint(tx[1], tz[1]);
 
+    #ifndef WITH_GODOT
     if (!facing(tx, ty, tz)) {
+    #endif
         if (depth < 2) {
             tx[3] = tx[2];
             ty[3] = ty[2];
@@ -548,7 +554,9 @@ rockrep:
         } else {
             poly3d(tx, ty, tz, 3, rc[1]);
         }
+    #ifndef WITH_GODOT
     }
+    #endif
 
     tx[0] = px[2];
     tx[1] = px[0];
@@ -557,7 +565,9 @@ rockrep:
     ty[0] = hpoint(tx[0], tz[0]);
     ty[1] = hpoint(tx[1], tz[1]);
 
+    #ifndef WITH_GODOT
     if (!facing(tx, ty, tz)) {
+    #endif
         if (depth < 2) {
             tx[3] = tx[2];
             ty[3] = ty[2];
@@ -566,7 +576,9 @@ rockrep:
         } else {
             poly3d(tx, ty, tz, 3, rc[2]);
         }
+    #ifndef WITH_GODOT
     }
+    #endif
 
     x = x + fast_flandom() * 1000 * cdown - fast_flandom() * 1000 * cdown;
     z = z + fast_flandom() * 1000 * cdown - fast_flandom() * 1000 * cdown;

--- a/src/noctis-1.cpp
+++ b/src/noctis-1.cpp
@@ -1089,8 +1089,12 @@ inactive:
 
 int8_t capture_poly3d = POLY3D_CAPTURE_NONE;
 
+extern void cb_ScatteringBegin();
+extern void cb_ScatteringEnd();
+
 void srf_detail(float x, float y, float z, int32_t depth, int8_t _class_) {
     //godot::UtilityFunctions::printt("srf_detail(", x, ", ", y, ", ", z, ", ", depth, ", ", _class_, ")");
+    cb_ScatteringBegin();
     // disegna un oggetto sulla superficie di un pianeta.
     switch (_class_) {
     case ROCKS: // rocce, sassi, massi, pietre, pietruzze etc...
@@ -1113,6 +1117,7 @@ void srf_detail(float x, float y, float z, int32_t depth, int8_t _class_) {
     case NOTHING: // una parte non coperta dalla texture (rovine).
         break;
     }
+    cb_ScatteringEnd();
 }
 
 int8_t gtx; // se attivo, traccia il livello del suolo con texture specifica

--- a/src/noctis-1.cpp
+++ b/src/noctis-1.cpp
@@ -1239,14 +1239,16 @@ void fragmentWC(int32_t x, int32_t z, bool capture) {
     // visibility diagonally (from 80 quadrants to 64) according
     // with the decision to trace with maximum precision, and went
     // from depth / 3 to depth / 2 (with a shift, by the way)
-    if (c1 < 00) {
-        c1 = 00;
-    }
+    if (!capture) {
+        if (c1 < 00) {
+            c1 = 00;
+        }
 
-    c1 += depth >> 1;
+        c1 += depth >> 1;
 
-    if (c1 > 32) {
-        c1 = 32;
+        if (c1 > 32) {
+            c1 = 32;
+        }
     }
 
     // depth culling dei territori lontani (per velocizzare).

--- a/src/noctis-d.h
+++ b/src/noctis-d.h
@@ -188,3 +188,9 @@ struct wasdmov {
     bool left;
     bool right;
 };
+
+// poly3d capture
+
+#define POLY3D_CAPTURE_NONE 0
+#define POLY3D_CAPTURE_SCATTERING 1
+#define POLY3D_CAPTURE_SURFACE 2

--- a/src/tdpolygs_stub.h
+++ b/src/tdpolygs_stub.h
@@ -1,3 +1,5 @@
+#include "godot_cpp/variant/utility_functions.hpp"
+
 #pragma once
 
 uint8_t escrescenze = 0xE0; // primo colore dei bumps (escrescenze)
@@ -118,7 +120,16 @@ void stick3d (float p_x, float p_y, float p_z, float x, float y, float z) {
    */
 }
 
+extern void cb_SurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
+extern bool capture_poly3d;
+
 void poly3d(const float *x, const float *y, const float *z, uint16_t nrv, uint8_t colore) {
+    if (!capture_poly3d) {
+        return;
+    }
+    if (nrv == 3) {
+        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
+    }
    // assuming nrv is always 4...
    /*
    FILE *fp;
@@ -138,6 +149,14 @@ void poly3d(const float *x, const float *y, const float *z, uint16_t nrv, uint8_
 }
 
 void polymap(float *x, float *y, float *z, int8_t nv, uint8_t tinta) {
+    if (!capture_poly3d) {
+        return;
+    }
+    if (nv == 3) {
+        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
+    } else if (nv == 4) {
+        godot::UtilityFunctions::printt("WARNING: not implemented polymap(...) for nv==4");
+    }
 }
 
 uint8_t *txtr; /* Area della texture (FLS a livelli di intensit�,

--- a/src/tdpolygs_stub.h
+++ b/src/tdpolygs_stub.h
@@ -120,19 +120,19 @@ void stick3d (float p_x, float p_y, float p_z, float x, float y, float z) {
    */
 }
 
-extern void cb_SurfacePolygon3Found(double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
-extern bool capture_poly3d;
+extern void cb_SurfacePolygon3Found(int8_t what, double x0, double x1, double x2, double y0, double y1, double y2, double z0, double z1, double z2, int colore);
+extern int8_t capture_poly3d;
 
 void poly3d(const float *x, const float *y, const float *z, uint16_t nrv, uint8_t colore) {
-    if (!capture_poly3d) {
+    if (capture_poly3d == POLY3D_CAPTURE_NONE) {
         return;
     }
     if (nrv == 3) {
-        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
     } else if (nrv == 4) {
         godot::UtilityFunctions::printt("WARNING: unverified implementation of poly3d(...) for nrv==4");
-        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
-        cb_SurfacePolygon3Found(x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], colore);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], colore);
     }
    // assuming nrv is always 4...
    /*
@@ -153,14 +153,14 @@ void poly3d(const float *x, const float *y, const float *z, uint16_t nrv, uint8_
 }
 
 void polymap(float *x, float *y, float *z, int8_t nv, uint8_t tinta) {
-    if (!capture_poly3d) {
+    if (capture_poly3d == POLY3D_CAPTURE_NONE) {
         return;
     }
     if (nv == 3) {
-        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
     } else if (nv == 4) {
-        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
-        cb_SurfacePolygon3Found(x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], tinta);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
+        cb_SurfacePolygon3Found(capture_poly3d, x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], tinta);
     }
 }
 

--- a/src/tdpolygs_stub.h
+++ b/src/tdpolygs_stub.h
@@ -129,6 +129,10 @@ void poly3d(const float *x, const float *y, const float *z, uint16_t nrv, uint8_
     }
     if (nrv == 3) {
         cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
+    } else if (nrv == 4) {
+        godot::UtilityFunctions::printt("WARNING: unverified implementation of poly3d(...) for nrv==4");
+        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], colore);
+        cb_SurfacePolygon3Found(x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], colore);
     }
    // assuming nrv is always 4...
    /*
@@ -155,7 +159,8 @@ void polymap(float *x, float *y, float *z, int8_t nv, uint8_t tinta) {
     if (nv == 3) {
         cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
     } else if (nv == 4) {
-        godot::UtilityFunctions::printt("WARNING: not implemented polymap(...) for nv==4");
+        cb_SurfacePolygon3Found(x[0], x[1], x[2], y[0], y[1], y[2], z[0], z[1], z[2], tinta);
+        cb_SurfacePolygon3Found(x[0], x[3], x[2], y[0], y[3], y[2], z[0], z[3], z[2], tinta);
     }
 }
 


### PR DESCRIPTION
This PR implements two things: surface mesh forwarding, and surface scattering. Surface mesh forwarding allows using the original NIV engine to create polygons. Surface scattering is supported in two ways;
1. Through signals emitted that can be listened on to get polygon coordinates
2. The GDExtension can also create meshes and nodes itself (this is slow at render time though!)

Neither solution is perfect; signals may cause some performance loss. But at least this works as a proof of concept.